### PR TITLE
Remove mutation of original values when sorting arrays

### DIFF
--- a/lib/crimp.rb
+++ b/lib/crimp.rb
@@ -36,7 +36,7 @@ module Crimp
   end
 
   def self.parse_array(array)
-    array.map! { |e| stringify(e) }.sort!
+    array.map { |e| stringify(e) }.sort
   end
 
   def self.parse_hash(hash)

--- a/lib/crimp/version.rb
+++ b/lib/crimp/version.rb
@@ -1,3 +1,3 @@
 module Crimp
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/spec/crimp_spec.rb
+++ b/spec/crimp_spec.rb
@@ -11,11 +11,16 @@ describe Crimp do
       specify { expect(subject.signature(hash)).to be_a String }
 
       it 'returns MD5 hash of stringified Hash' do
-        expect(
-          subject.signature(hash)
-        ).to eq(
-          Digest::MD5.hexdigest(subject.stringify(hash))
-        )
+        expect(subject.signature(hash)).to eq(Digest::MD5.hexdigest(subject.stringify(hash)))
+      end
+
+      it 'does not modify original hash' do
+        original_hash = { d: 'd', a: { c: 'c', b: 'b' } }
+        expected_hash = { d: 'd', a: { c: 'c', b: 'b' } }
+
+        subject.signature(original_hash)
+
+        expect(original_hash).to eq(expected_hash)
       end
     end
 
@@ -23,11 +28,16 @@ describe Crimp do
       specify { expect(subject.signature(array)).to be_a String }
 
       it 'returns MD5 hash of stringified Array' do
-        expect(
-          subject.signature(array)
-        ).to eq(
-          Digest::MD5.hexdigest(subject.stringify(array))
-        )
+        expect(subject.signature(array)).to eq(Digest::MD5.hexdigest(subject.stringify(array)))
+      end
+
+      it 'does not modify original array' do
+        original_array = [5, 4, 2, 6, [5, 7, 2]]
+        expected_array = [5, 4, 2, 6, [5, 7, 2]]
+
+        subject.signature(original_array)
+
+        expect(original_array).to eq(expected_array)
       end
     end
   end
@@ -37,11 +47,16 @@ describe Crimp do
       specify { expect(subject.stringify(hash)).to be_a String }
 
       it 'returns equal strings for differently ordered hashes' do
-        expect(
-          subject.stringify(hash)
-        ).to eq(
-          subject.stringify(hash_unordered)
-        )
+        expect(subject.stringify(hash)).to eq(subject.stringify(hash_unordered))
+      end
+
+      it 'does not modify original hash' do
+        original_hash = { d: 'd', a: { c: 'c', b: 'b' } }
+        expected_hash = { d: 'd', a: { c: 'c', b: 'b' } }
+
+        subject.signature(original_hash)
+
+        expect(original_hash).to eq(expected_hash)
       end
     end
 
@@ -49,11 +64,16 @@ describe Crimp do
       specify { expect(subject.stringify(array)).to be_a String }
 
       it 'returns equal strings for differently ordered arrays' do
-        expect(
-          subject.stringify(array)
-        ).to eq(
-          subject.stringify(array_unordered)
-        )
+        expect(subject.stringify(array)).to eq(subject.stringify(array_unordered))
+      end
+
+      it 'does not modify original array' do
+        original_array = [5, 4, 2, 6, [5, 7, 2]]
+        expected_array = [5, 4, 2, 6, [5, 7, 2]]
+
+        subject.signature(original_array)
+
+        expect(original_array).to eq(expected_array)
       end
     end
   end


### PR DESCRIPTION
Crimp mutates the original arrays that are passed into it. This should not be the expected behaviour, as it should only sort values to generate a unique signature/hash value.

**This removes the sort mutation.**