### PR TITLE
Possible fix for #4

### DIFF
--- a/lib/crimp.rb
+++ b/lib/crimp.rb
@@ -40,7 +40,7 @@ module Crimp
   end
 
   def self.parse_hash(hash)
-    stringify hash_to_array(hash)
+    stringify(hash_to_array(hash)).sub(/Array$/, 'Hash')
   end
 
   def self.to_string(obj)


### PR DESCRIPTION
Reasonable hack: makes all hashes get `Hash` suffix instead of `Array` suffix
Makes stringify `{}` output `[]Hash` instead of `[]Array`.